### PR TITLE
fix: prevent crash when addr->if_addr is NULL for an interface

### DIFF
--- a/netifaces/_netifaces.c
+++ b/netifaces/_netifaces.c
@@ -1253,6 +1253,9 @@ ifaddrs (PyObject *self, PyObject *args)
   }
 
   for (addr = addrs; addr; addr = addr->ifa_next) {
+    if (!addr->ifa_addr)
+      continue;
+
     if (addr->ifa_name == NULL || strcmp (addr->ifa_name, ifname) != 0)
       continue;
 
@@ -1371,6 +1374,9 @@ allifaddrs (PyObject *self)
   }
 
   for (addr = addrs; addr; addr = addr->ifa_next) {
+    if (!addr->ifa_addr)
+      continue;
+
     PyObject *ifinfo = getifaddrsinfo(addr);
     if (!ifinfo)
       continue;


### PR DESCRIPTION
This PR fixes the segmentation fault mentioned in https://github.com/tsukumijima/netifaces-plus/issues/2 when the computer has a network interface where `addr->ifa_addr` is a null pointer. This can happen for Tailscale interfaces for sure, but probably other types of network interfaces are also affected.