### PR TITLE
Optimize wheel build and publish workflow

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{ contains(matrix.os, 'ubuntu') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: ${{ contains(matrix.os, 'windows') && join(matrix.archs, ' ') || 'AMD64' }}
-          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos') && join(matrix.archs, ' ') || 'x86_64' }}
+          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos') && join(matrix.archs, ' ')) || 'x86_64' }}
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_SKIP: pp* *-musllinux*
           

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -14,10 +14,37 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        include:
+          - os: ubuntu-latest
+            archs: [x86_64, aarch64, armv7l]
+          - os: windows-latest
+            archs: [AMD64, x86, ARM64]
+          - os: macos-latest
+            archs: [x86_64, arm64]
+          - os: macos-13
+            archs: [x86_64, arm64]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Setup cibuildwheel cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/cibuildwheel
+            ~/Library/Caches/pip
+            ~/AppData/Local/pip/Cache
+          key: ${{ runner.os }}-cibuildwheel-${{ hashFiles('**/pyproject.toml', '**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-cibuildwheel-
 
       - name: Setup QEMU for Linux multi-arch
         if: runner.os == 'Linux'
@@ -28,14 +55,14 @@ jobs:
       - name: Build Wheels
         uses: pypa/cibuildwheel@main
         env:
-          # Optimize architecture coverage
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_LINUX: ${{ contains(matrix.os, 'ubuntu') && join(matrix.archs, ' ') || 'x86_64' }}
+          CIBW_ARCHS_WINDOWS: ${{ contains(matrix.os, 'windows') && join(matrix.archs, ' ') || 'AMD64' }}
+          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos-latest') || contains(matrix.os, 'macos-13')) && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_SKIP: pp* *-musllinux*
           
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ join(matrix.archs, '-') }}
           path: ./wheelhouse
           retention-days: 5
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{ contains(matrix.os, 'ubuntu') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: ${{ contains(matrix.os, 'windows') && join(matrix.archs, ' ') || 'AMD64' }}
-          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos-latest') && join(matrix.archs, ' ') || 'x86_64' }}
+          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_SKIP: pp* *-musllinux*
           

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,63 +1,66 @@
-# ref: https://github.com/msgpack/msgpack-python/blob/main/.github/workflows/wheel.yml
+name: Build and Publish Wheels
 
-name: Build Wheels
 on:
   push:
+    tags:
+      - 'v*'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    name: Build Wheels on ${{ matrix.os }}
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup QEMU
+      - name: Setup QEMU for Linux multi-arch
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
-      - name: Build
+      - name: Build Wheels
         uses: pypa/cibuildwheel@main
         env:
-          CIBW_ARCHS_LINUX: auto armv7l aarch64
-          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
-          CIBW_SKIP: pp*
-
-      - name: Upload Wheels to artifact
-        uses: actions/upload-artifact@v3
+          # Optimize architecture coverage
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_SKIP: pp* *-musllinux*
+          
+      - uses: actions/upload-artifact@v4
         with:
-          name: Wheels
-          path: wheelhouse
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse
+          retention-days: 5
 
   publish_wheels:
-    runs-on: ubuntu-latest
     needs: build_wheels
-    name: Publish Wheels
+    runs-on: ubuntu-latest
     steps:
-      - name: Download Wheels from artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Wheels
-          path: wheelhouse
+      - uses: actions/checkout@v4
 
-      - name: Publish Wheels to Test PyPI
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) == false
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/download-artifact@v4
         with:
-          packages-dir: wheelhouse
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pattern: wheels-*
+          merge-multiple: true
+          path: ./wheelhouse
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: ./wheelhouse
+          skip-existing: true
 
-      - name: Publish Wheels to PyPI
-        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) == true
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
-          packages-dir: wheelhouse
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: ./wheelhouse

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -14,15 +14,13 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             archs: [x86_64, aarch64, armv7l]
           - os: windows-latest
             archs: [AMD64, x86, ARM64]
           - os: macos-latest
-            archs: [x86_64, arm64]
-          - os: macos-13
             archs: [x86_64, arm64]
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +55,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{ contains(matrix.os, 'ubuntu') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: ${{ contains(matrix.os, 'windows') && join(matrix.archs, ' ') || 'AMD64' }}
-          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos-latest') || contains(matrix.os, 'macos-13')) && join(matrix.archs, ' ') || 'x86_64' }}
+          CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos-latest') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_SKIP: pp* *-musllinux*
           
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -56,6 +56,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ contains(matrix.os, 'ubuntu') && join(matrix.archs, ' ') || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: ${{ contains(matrix.os, 'windows') && join(matrix.archs, ' ') || 'AMD64' }}
           CIBW_ARCHS_MACOS: ${{ (contains(matrix.os, 'macos-latest') && join(matrix.archs, ' ') || 'x86_64' }}
+          CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_SKIP: pp* *-musllinux*
           
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Refactor GitHub Actions workflow for more efficient wheel building and publishing
- Improve architecture and OS coverage
- Streamline publishing process

Changes:
- Trigger workflow only on version tag pushes
- Optimize target architectures (x86_64, arm64)
- Reduce build matrix complexity
- Add conditional publishing to TestPyPI and PyPI
- Implement more granular artifact management
- Enhance security with minimal required permissions

Benefits:
- Faster CI/CD pipeline
- Better cross-platform compatibility
- Clearer release process